### PR TITLE
Trigger immediate availability refresh on month navigation

### DIFF
--- a/assets/js/modules/availability.js
+++ b/assets/js/modules/availability.js
@@ -15,6 +15,7 @@ let emptyState;
 let fetchTimer;
 let controller;
 let lastSignature = null;
+let lastVisibleMonth;
 
 function isLastDayOfMonth(isoDate) {
     if (typeof isoDate !== 'string' || isoDate.length < 10) {
@@ -283,8 +284,14 @@ async function fetchAvailability() {
     }
 }
 
-function scheduleFetch() {
+function scheduleFetch({ immediate = false } = {}) {
     window.clearTimeout(fetchTimer);
+
+    if (immediate) {
+        fetchAvailability();
+        return;
+    }
+
     fetchTimer = window.setTimeout(fetchAvailability, 300);
 }
 
@@ -313,10 +320,16 @@ export function initAvailability() {
     }
 
     subscribe((state) => {
+        const visibleMonthChanged = lastVisibleMonth && state.visibleMonth !== lastVisibleMonth;
+
         renderTimeslots(state);
-        scheduleFetch();
+
+        lastVisibleMonth = state.visibleMonth;
+
+        scheduleFetch({ immediate: Boolean(visibleMonthChanged) });
     });
 
+    lastVisibleMonth = getState().visibleMonth;
     scheduleFetch();
 }
 

--- a/partials/form/component-calendar.php
+++ b/partials/form/component-calendar.php
@@ -34,7 +34,7 @@ $weekdayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
     </header>
 
     <div class="relative rounded-xl border border-slate-200 p-5 shadow-xs" data-calendar>
-        <div class="absolute inset-0 z-10 hidden items-center justify-center rounded-xl bg-white/80" data-calendar-loading>
+        <div class="absolute inset-0 z-10 hidden items-center justify-center rounded-xl bg-white" data-calendar-loading>
             <div class="h-10 w-10 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"></div>
         </div>
 


### PR DESCRIPTION
## Summary
- trigger the availability refresh immediately when the visible month changes via navigation
- retain the debounce for other state changes by tracking the previous visible month
- make the calendar loading overlay fully opaque to hide the calendar while loading

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc52581e5883299318932f7fb6435e