### PR TITLE
Normalize Vite build output directory

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,12 +5,30 @@ export default defineConfig({
   root: '.',
   publicDir: false,
   build: {
-    outDir: 'public/assets/js',
+    outDir: 'public/assets',
     emptyOutDir: false,
     rollupOptions: {
       input: path.resolve(__dirname, 'assets/js/main.js'),
       output: {
-        entryFileNames: 'main.js',
+        entryFileNames: 'js/main.js',
+        chunkFileNames: 'js/[name].js',
+        assetFileNames: (assetInfo) => {
+          const extension = path.extname(assetInfo.name ?? '').toLowerCase();
+
+          if (extension === '.css') {
+            return 'css/[name][extname]';
+          }
+
+          if (['.woff', '.woff2', '.ttf', '.otf', '.eot'].includes(extension)) {
+            return 'fonts/[name][extname]';
+          }
+
+          if (['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.avif'].includes(extension)) {
+            return 'images/[name][extname]';
+          }
+
+          return 'js/[name][extname]';
+        },
         format: 'es'
       }
     }


### PR DESCRIPTION
## Summary
- update the Vite configuration to emit bundles into `public/assets`
- keep entry, chunk, and asset files grouped in predictable subdirectories for JS, CSS, images, and fonts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc6cbdff1c83298e0551d6c8837e2d