### PR TITLE
Copy static asset directories during Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,18 +1,80 @@
 import { defineConfig } from 'vite';
 import path from 'path';
+import { existsSync } from 'fs';
+import { mkdir, readdir, rm, copyFile } from 'fs/promises';
+
+const STATIC_ASSET_DIRECTORIES = [
+  { source: 'assets/icons', target: 'public/assets/icons' },
+  { source: 'assets/images', target: 'public/assets/images' },
+  { source: 'assets/fonts', target: 'public/assets/fonts' }
+];
+
+async function copyDirectoryRecursive(source, destination) {
+  await mkdir(destination, { recursive: true });
+  const entries = await readdir(source, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+
+    if (entry.isDirectory()) {
+      await copyDirectoryRecursive(sourcePath, destinationPath);
+    } else if (entry.isFile()) {
+      await copyFile(sourcePath, destinationPath);
+    }
+  }
+}
+
+function copyStaticAssets() {
+  return {
+    name: 'copy-static-assets',
+    closeBundle: async () => {
+      for (const { source, target } of STATIC_ASSET_DIRECTORIES) {
+        const resolvedSource = path.resolve(__dirname, source);
+
+        if (!existsSync(resolvedSource)) {
+          continue;
+        }
+
+        const resolvedTarget = path.resolve(__dirname, target);
+        await rm(resolvedTarget, { recursive: true, force: true });
+        await copyDirectoryRecursive(resolvedSource, resolvedTarget);
+      }
+    }
+  };
+}
 
 export default defineConfig({
   root: '.',
   publicDir: false,
   build: {
-    outDir: 'public/assets/js',
+    outDir: 'public/assets',
     emptyOutDir: false,
     rollupOptions: {
       input: path.resolve(__dirname, 'assets/js/main.js'),
       output: {
-        entryFileNames: 'main.js',
+        entryFileNames: 'js/main.js',
+        chunkFileNames: 'js/[name].js',
+        assetFileNames: (assetInfo) => {
+          const extension = path.extname(assetInfo.name ?? '').toLowerCase();
+
+          if (extension === '.css') {
+            return 'css/[name][extname]';
+          }
+
+          if (['.woff', '.woff2', '.ttf', '.otf', '.eot'].includes(extension)) {
+            return 'fonts/[name][extname]';
+          }
+
+          if (['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.avif'].includes(extension)) {
+            return 'images/[name][extname]';
+          }
+
+          return 'js/[name][extname]';
+        },
         format: 'es'
       }
     }
-  }
+  },
+  plugins: [copyStaticAssets()]
 });


### PR DESCRIPTION
## Summary
- add a custom Vite plugin that copies icons, images, and fonts into the `public/assets` tree after each build
- ensure the build output directories are recreated so stale assets do not linger between runs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc6cbdff1c83298e0551d6c8837e2d