### PR TITLE
Adjust guest type fallback range to respect max values

### DIFF
--- a/assets/js/modules/guest-types.js
+++ b/assets/js/modules/guest-types.js
@@ -11,7 +11,7 @@ let controller;
 let lastSignature = null;
 
 const FETCH_DEBOUNCE_MS = 250;
-const DEFAULT_GUEST_RANGE = 9;
+const DEFAULT_GUEST_RANGE = 10;
 
 function normaliseGuestTypeConfig(rawConfig) {
     const safeObject = (value) => (value && typeof value === 'object' ? value : {});

--- a/partials/form/component-guest-types.php
+++ b/partials/form/component-guest-types.php
@@ -11,7 +11,7 @@ $min = $guestConfig['min'] ?? [];
 $max = $guestConfig['max'] ?? [];
 $ids = $guestConfig['ids'] ?? [];
 
-$defaultGuestRange = 9;
+$defaultGuestRange = 10;
 
 $guestTypes = [];
 foreach ($ids as $id) {


### PR DESCRIPTION
## Summary
- update the server-rendered guest type selector fallback range so configured maximums stay inclusive
- align the client-side guest type fallback range with the server to present the full configured option list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd0317eeac8329b88252f207f91534