### PR TITLE
Hide description and price for checkbox guest types

### DIFF
--- a/partials/form/component-guest-types.php
+++ b/partials/form/component-guest-types.php
@@ -11,7 +11,7 @@ $min = $guestConfig['min'] ?? [];
 $max = $guestConfig['max'] ?? [];
 $ids = $guestConfig['ids'] ?? [];
 
-$defaultGuestRange = 9;
+$defaultGuestRange = 10;
 
 $guestTypes = [];
 foreach ($ids as $id) {
@@ -19,7 +19,8 @@ foreach ($ids as $id) {
     $minValue = isset($min[$stringId]) ? max(0, (int) $min[$stringId]) : 0;
     $maxCandidate = isset($max[$stringId]) ? max(0, (int) $max[$stringId]) : 0;
     $fallbackMax = $minValue + $defaultGuestRange;
-    $maxValue = $maxCandidate > $minValue ? $maxCandidate : $fallbackMax;
+    $maxValue = $maxCandidate >= $minValue ? $maxCandidate : $fallbackMax;
+    $controlType = $minValue === 1 && $maxValue === 1 ? 'checkbox' : 'select';
 
     $guestTypes[] = [
         'id' => $stringId,
@@ -28,6 +29,7 @@ foreach ($ids as $id) {
         'min' => $minValue,
         'max' => max($maxValue, $minValue),
         'fallbackMax' => $fallbackMax,
+        'control' => $controlType,
     ];
 }
 
@@ -45,45 +47,69 @@ $label = $bootstrap['activity']['uiLabels']['guestTypes'] ?? 'How many people ar
                 $minValue = $guestType['min'];
                 $maxValue = max($guestType['max'], $minValue);
                 $fallbackMax = max($guestType['fallbackMax'], $minValue);
-                $selectId = sprintf('guest-count-%s', preg_replace('/[^a-zA-Z0-9_-]/', '', $guestType['id']));
+                $sanitisedId = preg_replace('/[^a-zA-Z0-9_-]/', '', $guestType['id']);
+                $selectId = sprintf('guest-count-%s', $sanitisedId);
+                $checkboxId = sprintf('guest-toggle-%s', $sanitisedId);
+                $labelId = sprintf('guest-label-%s', $sanitisedId);
                 $description = $guestType['description'];
             ?>
-            <div class="flex flex-wrap items-center justify-between gap-6 pe-3 rounded-xl border border-slate-200 shadow-xs"
+            <?php $isCheckbox = $guestType['control'] === 'checkbox'; ?>
+            <div class="<?= $isCheckbox ? 'flex flex-wrap items-center justify-between' : 'flex flex-wrap items-center justify-between gap-6 pe-3 rounded-xl border border-slate-200 shadow-xs' ?>"
                  data-guest-type="<?= htmlspecialchars($guestType['id'], ENT_QUOTES, 'UTF-8') ?>"
                  data-min="<?= $minValue ?>"
                  data-max="<?= $maxValue ?>"
                  data-fallback-max="<?= $fallbackMax ?>">
-                <div class="flex items-center gap-4 min-w-0">
+                <div class="flex items-center <?= $isCheckbox ? 'gap-2' : 'gap-4' ?> min-w-0">
                     <div class="relative">
-                        <label class="sr-only" for="<?= htmlspecialchars($selectId, ENT_QUOTES, 'UTF-8') ?>">
-                            <?= htmlspecialchars(sprintf('Guest count for %s', $guestType['label']), ENT_QUOTES, 'UTF-8') ?>
-                        </label>
-                        <select id="<?= htmlspecialchars($selectId, ENT_QUOTES, 'UTF-8') ?>"
-                                name="guestCounts[<?= htmlspecialchars($guestType['id'], ENT_QUOTES, 'UTF-8') ?>]"
-                                class="h-12 w-20 appearance-none rounded-l-xl bg-blue-600 px-3 pr-8 text-center text-base font-normal text-white shadow-sm focus:outline-none"
-                                data-guest-select>
-                            <?php for ($value = $minValue; $value <= $maxValue; $value++): ?>
-                                <option value="<?= $value ?>"<?= $value === $minValue ? ' selected' : '' ?>><?= $value ?></option>
-                            <?php endfor; ?>
-                        </select>
-                        <span aria-hidden="true" class="pointer-events-none absolute inset-y-0 right-2 flex items-center text-sm text-blue-50">
-                            <?php
-                                $chevronIcon = file_get_contents(dirname(__DIR__, 2) . '/assets/icons/outline/chevron-up-down.svg');
-                                if ($chevronIcon !== false) {
-                                    echo str_replace('<svg', '<svg class="h-5 w-5" stroke-width="2"', $chevronIcon);
-                                }
-                            ?>
-                        </span>
+                        <?php if ($isCheckbox): ?>
+                            <input type="hidden"
+                                   name="guestCounts[<?= htmlspecialchars($guestType['id'], ENT_QUOTES, 'UTF-8') ?>]"
+                                   value="<?= $minValue ?>"
+                                   data-guest-checkbox-input>
+                            <input id="<?= htmlspecialchars($checkboxId, ENT_QUOTES, 'UTF-8') ?>"
+                                   type="checkbox"
+                                   class="h-5 w-5 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                                   aria-labelledby="<?= htmlspecialchars($labelId, ENT_QUOTES, 'UTF-8') ?>"
+                                   data-guest-checkbox
+                                   data-checked-value="<?= $minValue ?>"
+                                   data-unchecked-value="0"
+                                   value="<?= $minValue ?>"
+                                   checked>
+                        <?php else: ?>
+                            <label class="sr-only" for="<?= htmlspecialchars($selectId, ENT_QUOTES, 'UTF-8') ?>">
+                                <?= htmlspecialchars(sprintf('Guest count for %s', $guestType['label']), ENT_QUOTES, 'UTF-8') ?>
+                            </label>
+                            <select id="<?= htmlspecialchars($selectId, ENT_QUOTES, 'UTF-8') ?>"
+                                    name="guestCounts[<?= htmlspecialchars($guestType['id'], ENT_QUOTES, 'UTF-8') ?>]"
+                                    class="h-12 w-20 appearance-none rounded-l-xl bg-blue-600 px-3 pr-8 text-center text-base font-normal text-white shadow-sm focus:outline-none"
+                                    data-guest-select>
+                                <?php for ($value = $minValue; $value <= $maxValue; $value++): ?>
+                                    <option value="<?= $value ?>"<?= $value === $minValue ? ' selected' : '' ?>><?= $value ?></option>
+                                <?php endfor; ?>
+                            </select>
+                            <span aria-hidden="true" class="pointer-events-none absolute inset-y-0 right-2 flex items-center text-sm text-blue-50">
+                                <?php
+                                    $chevronIcon = file_get_contents(dirname(__DIR__, 2) . '/assets/icons/outline/chevron-up-down.svg');
+                                    if ($chevronIcon !== false) {
+                                        echo str_replace('<svg', '<svg class="h-5 w-5" stroke-width="2"', $chevronIcon);
+                                    }
+                                ?>
+                            </span>
+                        <?php endif; ?>
                     </div>
                     <div class="min-w-0 space-y-0">
-                        <p class="font-medium -mb-0.5" data-guest-label><?= htmlspecialchars($guestType['label'], ENT_QUOTES, 'UTF-8') ?></p>
-                        <p class="text-xs text-slate-500 mb-0<?= $description === null || $description === '' ? ' hidden' : '' ?>"
-                           data-guest-description><?= htmlspecialchars((string) $description, ENT_QUOTES, 'UTF-8') ?></p>
+                        <p class="font-medium -mb-0.5" id="<?= htmlspecialchars($labelId, ENT_QUOTES, 'UTF-8') ?>" data-guest-label><?= htmlspecialchars($guestType['label'], ENT_QUOTES, 'UTF-8') ?></p>
+                        <?php if (!$isCheckbox): ?>
+                            <p class="text-xs text-slate-500 mb-0<?= $description === null || $description === '' ? ' hidden' : '' ?>"
+                               data-guest-description><?= htmlspecialchars((string) $description, ENT_QUOTES, 'UTF-8') ?></p>
+                        <?php endif; ?>
                     </div>
                 </div>
-                <div class="text-right">
-                    <p class="text-sm font-normal text-slate-900 mb-0" data-guest-price>--</p>
-                </div>
+                <?php if (!$isCheckbox): ?>
+                    <div class="text-right">
+                        <p class="text-sm font-normal text-slate-900 mb-0" data-guest-price>--</p>
+                    </div>
+                <?php endif; ?>
             </div>
         <?php endforeach; ?>
     </div>


### PR DESCRIPTION
## Summary
- adjust checkbox guest type markup to remove price and description columns while keeping checkbox pre-selected

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd0317eeac8329b88252f207f91534