### PR TITLE
Handle guest type fallback when max below min

### DIFF
--- a/assets/js/modules/guest-types-range.js
+++ b/assets/js/modules/guest-types-range.js
@@ -1,0 +1,39 @@
+export function resolveGuestRange({
+    min,
+    max,
+    fallbackMax,
+    hasExplicitMax = false,
+    defaultRange = 10,
+}) {
+    const boundedMin = Number.isFinite(min) ? Math.max(0, Math.floor(min)) : 0;
+
+    const fallbackFloor = Number.isFinite(fallbackMax) ? Math.floor(fallbackMax) : Number.NaN;
+    let normalisedFallback = Number.isFinite(fallbackFloor)
+        ? Math.max(boundedMin, fallbackFloor)
+        : Number.NaN;
+
+    if (!Number.isFinite(normalisedFallback) || normalisedFallback <= boundedMin) {
+        normalisedFallback = boundedMin + defaultRange;
+    }
+
+    const maxCandidate = Number(max);
+    const hasValidMax = Number.isFinite(maxCandidate);
+    const flooredMax = hasValidMax ? Math.floor(maxCandidate) : Number.NaN;
+
+    let boundedMax = hasValidMax ? Math.max(boundedMin, flooredMax) : boundedMin;
+    const maxBelowMin = hasValidMax && flooredMax < boundedMin;
+
+    if (maxBelowMin) {
+        boundedMax = normalisedFallback;
+    } else if (!hasExplicitMax && boundedMax === boundedMin) {
+        boundedMax = normalisedFallback;
+    }
+
+    return {
+        min: boundedMin,
+        max: boundedMax,
+        fallbackMax: Math.max(boundedMax, normalisedFallback),
+    };
+}
+
+export default resolveGuestRange;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tailwindcss -i ./assets/css/tailwind.css -o ./public/assets/css/main.css --minify && vite build",
     "lint": "eslint \"assets/js/**/*.js\"",
     "format": "prettier --write \"assets/js/**/*.js\"",
-    "test": "playwright test"
+    "test": "node --test tests/js/**/*.mjs && playwright test tests/playwright"
   },
   "keywords": [],
   "author": "",

--- a/tests/js/guest-types-range.test.mjs
+++ b/tests/js/guest-types-range.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveGuestRange } from '../../assets/js/modules/guest-types-range.js';
+
+test('uses fallback range when max is below min despite explicit max', () => {
+  const result = resolveGuestRange({
+    min: 4,
+    max: 1,
+    fallbackMax: 9,
+    hasExplicitMax: true,
+    defaultRange: 10,
+  });
+
+  assert.equal(result.min, 4);
+  assert.equal(result.max, 9);
+  assert.equal(result.fallbackMax, 9);
+});
+
+test('keeps single value when explicit min equals max', () => {
+  const result = resolveGuestRange({
+    min: 2,
+    max: 2,
+    fallbackMax: 8,
+    hasExplicitMax: true,
+    defaultRange: 10,
+  });
+
+  assert.equal(result.min, 2);
+  assert.equal(result.max, 2);
+  assert.equal(result.fallbackMax, 8);
+});


### PR DESCRIPTION
## Summary
- centralize guest range calculation so fallback options are used when an explicit max is lower than the minimum while preserving the single-value checkbox case
- update guest type syncing to rely on the new helper and carry forward the resolved fallback range
- add a Node-based test for the guest range logic and wire it into the npm test script alongside the existing Playwright suite

## Testing
- node --test tests/js/**/*.mjs
- npm test *(fails: Playwright browsers are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd13c6ec4c832995c7f918d47a3066