### PR TITLE
Hide guest price for private activities

### DIFF
--- a/partials/form/component-guest-types.php
+++ b/partials/form/component-guest-types.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 $page = $pageContext ?? [];
 $bootstrap = $page['bootstrap'] ?? [];
 $guestConfig = $bootstrap['activity']['guestTypes'] ?? [];
+$isPrivateActivity = filter_var($bootstrap['activity']['privateActivity'] ?? false, FILTER_VALIDATE_BOOLEAN);
 $labels = $guestConfig['labels'] ?? [];
 $descriptions = $guestConfig['descriptions'] ?? [];
 $min = $guestConfig['min'] ?? [];
@@ -113,9 +114,11 @@ $label = $bootstrap['activity']['uiLabels']['guestTypes'] ?? 'How many people ar
                                data-guest-description><?= htmlspecialchars((string) $description, ENT_QUOTES, 'UTF-8') ?></p>
                         </div>
                     </div>
-                    <div class="text-right">
-                        <p class="text-sm font-normal text-slate-900 mb-0" data-guest-price>--</p>
-                    </div>
+                    <?php if (! $isPrivateActivity): ?>
+                        <div class="text-right">
+                            <p class="text-sm font-normal text-slate-900 mb-0" data-guest-price>--</p>
+                        </div>
+                    <?php endif; ?>
                 </div>
             <?php endif; ?>
         <?php endforeach; ?>

--- a/public/index.php
+++ b/public/index.php
@@ -145,6 +145,7 @@ $bootstrapData = [
         'infoBlocks' => $activityConfig['infoBlocks'] ?? [],
         'transportation' => $activityConfig['transportation'] ?? [],
         'upgrades' => $activityConfig['upgrades'] ?? [],
+        'privateActivity' => filter_var($activityConfig['privateActivity'] ?? false, FILTER_VALIDATE_BOOLEAN),
         'currency' => [
             'code' => strtoupper((string) ($activityConfig['currency']['code'] ?? 'USD')),
             'symbol' => $activityConfig['currency']['symbol'] ?? '$',


### PR DESCRIPTION
## Summary
- expose the privateActivity flag in the activity bootstrap payload
- hide the guest price block in the guest type selector when privateActivity is true

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9d1c20f0832997baec395ceaea3f