### PR TITLE
Hide guest price for private activities

### DIFF
--- a/assets/js/modules/guest-types.js
+++ b/assets/js/modules/guest-types.js
@@ -334,6 +334,7 @@ function syncFromState(state) {
         const labelElement = qs('[data-guest-label]', container);
         const descriptionElement = qs('[data-guest-description]', container);
         const priceElement = qs('[data-guest-price]', container);
+        const priceSpinner = qs('[data-guest-price-spinner]', container);
 
         const detail = detailMap.get(id) || null;
 
@@ -416,16 +417,33 @@ function syncFromState(state) {
             }
         }
 
+        const hasDetail = Boolean(detail);
+        const hasLoadedGuestDetails = Array.isArray(details) && details.length > 0;
+        const isLoadingPrices = Boolean(state.loading && state.loading.guestTypes);
+
         if (priceElement) {
-            if (!detail || detail.price === null || detail.price === undefined || Number.isNaN(Number(detail.price))) {
-                priceElement.textContent = 'Price available at checkout';
-            } else if (Number(detail.price) === 0) {
-                priceElement.textContent = 'Included';
+            const shouldShowSpinner = isLoadingPrices || (!hasDetail && !hasLoadedGuestDetails);
+
+            if (priceSpinner) {
+                priceSpinner.classList.toggle('hidden', !shouldShowSpinner);
+            }
+
+            if (shouldShowSpinner) {
+                priceElement.textContent = '';
+                priceElement.classList.add('hidden');
             } else {
-                priceElement.textContent = formatCurrency(Number(detail.price), {
-                    currency: currencyCode,
-                    locale: currencyLocale,
-                });
+                priceElement.classList.remove('hidden');
+
+                if (!hasDetail || detail.price === null || detail.price === undefined || Number.isNaN(Number(detail.price))) {
+                    priceElement.textContent = 'Price available at checkout';
+                } else if (Number(detail.price) === 0) {
+                    priceElement.textContent = 'Included';
+                } else {
+                    priceElement.textContent = formatCurrency(Number(detail.price), {
+                        currency: currencyCode,
+                        locale: currencyLocale,
+                    });
+                }
             }
         }
     });

--- a/partials/form/component-guest-types.php
+++ b/partials/form/component-guest-types.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 $page = $pageContext ?? [];
 $bootstrap = $page['bootstrap'] ?? [];
 $guestConfig = $bootstrap['activity']['guestTypes'] ?? [];
+$isPrivateActivity = filter_var($bootstrap['activity']['privateActivity'] ?? false, FILTER_VALIDATE_BOOLEAN);
 $labels = $guestConfig['labels'] ?? [];
 $descriptions = $guestConfig['descriptions'] ?? [];
 $min = $guestConfig['min'] ?? [];
@@ -113,9 +114,14 @@ $label = $bootstrap['activity']['uiLabels']['guestTypes'] ?? 'How many people ar
                                data-guest-description><?= htmlspecialchars((string) $description, ENT_QUOTES, 'UTF-8') ?></p>
                         </div>
                     </div>
-                    <div class="text-right">
-                        <p class="text-sm font-normal text-slate-900 mb-0" data-guest-price>--</p>
-                    </div>
+                    <?php if (! $isPrivateActivity): ?>
+                        <div class="flex items-center justify-end gap-2 text-right" data-guest-price-container>
+                            <span class="hidden h-4 w-4 animate-spin rounded-full border-2 border-blue-200 border-t-blue-600"
+                                  aria-hidden="true"
+                                  data-guest-price-spinner></span>
+                            <p class="text-sm font-normal text-slate-900 mb-0" data-guest-price>--</p>
+                        </div>
+                    <?php endif; ?>
                 </div>
             <?php endif; ?>
         <?php endforeach; ?>

--- a/public/index.php
+++ b/public/index.php
@@ -145,6 +145,7 @@ $bootstrapData = [
         'infoBlocks' => $activityConfig['infoBlocks'] ?? [],
         'transportation' => $activityConfig['transportation'] ?? [],
         'upgrades' => $activityConfig['upgrades'] ?? [],
+        'privateActivity' => filter_var($activityConfig['privateActivity'] ?? false, FILTER_VALIDATE_BOOLEAN),
         'currency' => [
             'code' => strtoupper((string) ($activityConfig['currency']['code'] ?? 'USD')),
             'symbol' => $activityConfig['currency']['symbol'] ?? '$',


### PR DESCRIPTION
## Summary
- expose the privateActivity flag in the activity bootstrap payload
- hide the guest price block in the guest type selector when privateActivity is true
- show a loading spinner in place of guest guest pricing while rates are loading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd9d1c20f0832997baec395ceaea3f