### PR TITLE
Fetch timeslots even when calendar shows sold out

### DIFF
--- a/controller/Services/AvailabilityService.php
+++ b/controller/Services/AvailabilityService.php
@@ -148,20 +148,16 @@ final class AvailabilityService
         }
 
         $requestedSeats = $this->calculateRequestedSeats($guestCounts, $activityConfig);
-        $timeslots = [];
-        $timeslotStatus = 'unavailable';
 
-        if (in_array($selectedDayStatus, ['available', 'limited'], true)) {
-            $timeslots = $this->fetchTimeslotsForDate(
-                $this->soapClientBuilder->build(),
-                $supplierConfig,
-                $activityIds,
-                $selectedDay->format('Y-m-d'),
-                $guestCounts
-            );
+        $timeslots = $this->fetchTimeslotsForDate(
+            $this->soapClientBuilder->build(),
+            $supplierConfig,
+            $activityIds,
+            $selectedDay->format('Y-m-d'),
+            $guestCounts
+        );
 
-            $timeslotStatus = $timeslots === [] ? 'unavailable' : 'available';
-        }
+        $timeslotStatus = $timeslots === [] ? 'unavailable' : 'available';
 
         return [
             'calendar' => $calendar,


### PR DESCRIPTION
## Summary
- always call the SOAP timeslot lookup for the selected day so real departures show up even when the calendar feed marks the date as sold out
- mark timeslot availability as available whenever the SOAP response returns departures
- extend the availability service tests to cover sold-out calendars with and without returned timeslots

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dda4e57bac8329bcc32ab08204d46e