### PR TITLE
Use extended availability metadata for timeslots

### DIFF
--- a/api/get-availability.php
+++ b/api/get-availability.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 require __DIR__ . '/../controller/Setup.php';
 
 use PonoRez\SGCForms\Services\AvailabilityService;
-use PonoRez\SGCForms\Services\SoapClientBuilder;
 use PonoRez\SGCForms\Support\ErrorHandler;
 use PonoRez\SGCForms\Support\RequestValidator;
 use PonoRez\SGCForms\Support\ResponseFormatter;
@@ -45,7 +44,7 @@ try {
         }
     }
 
-    $service = new AvailabilityService(new SoapClientBuilder());
+    $service = new AvailabilityService();
     $result = $service->fetchCalendar(
         $params['supplier'],
         $params['activity'],

--- a/suppliers/supplier-slug/activity-slug.config
+++ b/suppliers/supplier-slug/activity-slug.config
@@ -1,6 +1,11 @@
 {
   "activityId": 369,
   "activityIds": [369],
+  "departureLabels": {
+    "369": "7:30 AM Departure",
+    "482": "12:30 PM Departure",
+    "777": "2:00 PM Departure"
+  },
   "slug": "activity-slug",
   "displayName": "Activity Title Example",
   "summary": "A short highlight of the experience.",


### PR DESCRIPTION
## Summary
- derive per-day activity availability from the extended calendar feed so timeslot lists come from Ponorez JSON instead of SOAP fallbacks
- expose the extended availability map in API metadata and build the day’s timeslots from configured activity labels
- refresh sample configuration and availability tests to cover the new filtering behaviour

## Testing
- composer test *(fails: vendor/bin/phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dda4e57bac8329bcc32ab08204d46e