### PR TITLE
Surface extended availability in timeslot picker

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -146,6 +146,21 @@ $bootstrapData = [
         'transportation' => $activityConfig['transportation'] ?? [],
         'upgrades' => $activityConfig['upgrades'] ?? [],
         'privateActivity' => filter_var($activityConfig['privateActivity'] ?? false, FILTER_VALIDATE_BOOLEAN),
+        'departureLabels' => array_reduce(
+            array_keys($activityConfig['departureLabels'] ?? []),
+            static function (array $carry, $key) use ($activityConfig): array {
+                $stringKey = (string) $key;
+                $label = $activityConfig['departureLabels'][$key];
+
+                if ($stringKey === '' || $label === null) {
+                    return $carry;
+                }
+
+                $carry[$stringKey] = (string) $label;
+                return $carry;
+            },
+            []
+        ),
         'currency' => [
             'code' => strtoupper((string) ($activityConfig['currency']['code'] ?? 'USD')),
             'symbol' => $activityConfig['currency']['symbol'] ?? '$',


### PR DESCRIPTION
## Summary
- expose configured departure labels in the bootstrap payload so the UI can name timeslots consistently
- index extended availability activity IDs when building the calendar metadata and mark the selected date available when the JSON indicates open departures
- derive and filter the timeslot list in the browser from the extended metadata, falling back to SOAP data when present, and cover the behavior with new tests

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68ddaf73e6d08329ace2a276224c3815