### PR TITLE
Fix timeslot labels to use detailed values

### DIFF
--- a/tests/phpunit/Services/AvailabilityTest.php
+++ b/tests/phpunit/Services/AvailabilityTest.php
@@ -240,6 +240,54 @@ final class AvailabilityTest extends TestCase
         self::assertSame('8:00am Check In', $timeslots[0]->getLabel());
     }
 
+    public function testFetchCalendarUsesNestedDetailsTimesForTimeslotLabel(): void
+    {
+        $seats = [];
+        for ($day = 1; $day <= 31; $day++) {
+            $seats['d' . $day] = 10;
+        }
+
+        $httpResponse = json_encode([
+            'yearmonth_2024_8' => $seats,
+            'yearmonth_2024_8_ex' => [],
+        ], JSON_THROW_ON_ERROR);
+
+        $httpFetcher = fn () => $httpResponse;
+
+        $client = new AvailabilityRecordingSoapClient([
+            'getActivityTimeslots' => static fn () => [
+                'timeslots' => [
+                    [
+                        'id' => '5260',
+                        'label' => 'Departure 639',
+                        'details' => [
+                            'times' => [
+                                'provided' => '8:00am Check In',
+                                'display' => '8:00 AM Check-In',
+                            ],
+                        ],
+                        'available' => 12,
+                    ],
+                ],
+            ],
+        ]);
+        $factory = new AvailabilityStubSoapClientFactory($client);
+
+        $service = new AvailabilityService($factory, $httpFetcher);
+        $result = $service->fetchCalendar(
+            self::SUPPLIER_SLUG,
+            self::ACTIVITY_SLUG,
+            '2024-08-15',
+            ['345' => 2],
+            [369]
+        );
+
+        $timeslots = $result['timeslots'];
+        self::assertCount(1, $timeslots);
+        self::assertSame('5260', $timeslots[0]->getId());
+        self::assertSame('8:00am Check In', $timeslots[0]->getLabel());
+    }
+
     public function testFetchCalendarReturnsTimeslotsEvenWhenCalendarShowsSoldOut(): void
     {
         $seats = [];


### PR DESCRIPTION
## Summary
- prefer the timeslot details.times value when present so departure labels display the provided value
- improve detail value extraction to handle nested arrays and other structures
- add regression test covering nested detail payloads

## Testing
- vendor/bin/phpunit tests/phpunit/Services/AvailabilityTest.php

------
https://chatgpt.com/codex/tasks/task_e_68ddb7216cb883299b9631338227eb7c