### PR TITLE
Display Ponorez availability metadata in timeslot panel

### DIFF
--- a/partials/form/component-timeslot.php
+++ b/partials/form/component-timeslot.php
@@ -30,6 +30,7 @@ $timeslotEndpoint = $apiEndpoints['availability'] ?? null;
         <ul class="hidden divide-y divide-slate-200" data-timeslot-list role="radiogroup">
             <!-- Timeslots injected by JavaScript -->
         </ul>
+        <div class="hidden border-t border-slate-200 bg-slate-50 px-4 py-3 text-xs font-mono text-slate-600 whitespace-pre-wrap break-words" data-availability-metadata></div>
     </div>
 
     <?php if ($timeslotEndpoint): ?>


### PR DESCRIPTION
## Summary
- add a metadata panel beneath the timeslot radios to surface raw Ponorez availability details
- render and update the metadata block with formatted JSON when availability state changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb9af21f483299effb7c51935faf7