### PR TITLE
Expose timeslot details in availability response

### DIFF
--- a/assets/js/modules/availability.js
+++ b/assets/js/modules/availability.js
@@ -162,6 +162,31 @@ function mapCalendar(calendar = []) {
     }, []);
 }
 
+function normaliseTimeslotDetails(details) {
+    if (!details || typeof details !== 'object') {
+        return {};
+    }
+
+    return Object.entries(details).reduce((accumulator, [key, value]) => {
+        if (value === null || value === undefined) {
+            return accumulator;
+        }
+
+        const stringKey = String(key);
+        if (stringKey === '') {
+            return accumulator;
+        }
+
+        const stringValue = String(value);
+        if (stringValue === '') {
+            return accumulator;
+        }
+
+        accumulator[stringKey] = stringValue;
+        return accumulator;
+    }, {});
+}
+
 function mapTimeslots(timeslots = []) {
     return timeslots.reduce((accumulator, slot) => {
         if (!slot || slot.id === undefined) {
@@ -173,8 +198,9 @@ function mapTimeslots(timeslots = []) {
         const available = slot.available !== undefined && slot.available !== null
             ? Number(slot.available)
             : null;
+        const details = normaliseTimeslotDetails(slot.details);
 
-        accumulator.push({ id, label, available });
+        accumulator.push({ id, label, available, details });
         return accumulator;
     }, []);
 }

--- a/controller/DTO/Timeslot.php
+++ b/controller/DTO/Timeslot.php
@@ -6,10 +6,14 @@ namespace PonoRez\SGCForms\DTO;
 
 final class Timeslot
 {
+    /**
+     * @param array<string,string> $details
+     */
     public function __construct(
         private readonly string $id,
         private readonly string $label,
-        private readonly ?int $available = null
+        private readonly ?int $available = null,
+        private readonly array $details = []
     ) {
     }
 
@@ -28,12 +32,21 @@ final class Timeslot
         return $this->available;
     }
 
+    /**
+     * @return array<string,string>
+     */
+    public function getDetails(): array
+    {
+        return $this->details;
+    }
+
     public function toArray(): array
     {
         return [
             'id' => $this->id,
             'label' => $this->label,
             'available' => $this->available,
+            'details' => $this->details,
         ];
     }
 }

--- a/tests/phpunit/Services/AvailabilityTest.php
+++ b/tests/phpunit/Services/AvailabilityTest.php
@@ -238,6 +238,7 @@ final class AvailabilityTest extends TestCase
         self::assertCount(1, $timeslots);
         self::assertSame('5260', $timeslots[0]->getId());
         self::assertSame('8:00am Check In', $timeslots[0]->getLabel());
+        self::assertSame(['times' => '8:00am Check In'], $timeslots[0]->getDetails());
     }
 
     public function testFetchCalendarUsesNestedDetailsTimesForTimeslotLabel(): void
@@ -286,6 +287,7 @@ final class AvailabilityTest extends TestCase
         self::assertCount(1, $timeslots);
         self::assertSame('5260', $timeslots[0]->getId());
         self::assertSame('8:00am Check In', $timeslots[0]->getLabel());
+        self::assertSame(['times' => '8:00am Check In'], $timeslots[0]->getDetails());
     }
 
     public function testFetchCalendarReturnsTimeslotsEvenWhenCalendarShowsSoldOut(): void


### PR DESCRIPTION
## Summary
- retain the timeslot detail metadata returned by Ponorez and expose it via the availability API
- extend the Timeslot DTO with normalised detail strings and surface them to the frontend state mapper
- cover the new behaviour with updated availability service tests

## Testing
- composer test *(fails: vendor/bin/phpunit missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbd8e5f748329b9d2831ffb3d2ba5