### PR TITLE
Add activity info caching service and integrate into bootstrap

### DIFF
--- a/controller/Services/ActivityInfoService.php
+++ b/controller/Services/ActivityInfoService.php
@@ -1,0 +1,432 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PonoRez\SGCForms\Services;
+
+use JsonException;
+use PonoRez\SGCForms\Cache\CacheInterface;
+use PonoRez\SGCForms\Cache\CacheKeyGenerator;
+use PonoRez\SGCForms\UtilityService;
+use SoapClient;
+use SoapFault;
+use Throwable;
+
+final class ActivityInfoService
+{
+    private const CACHE_KEY_PREFIX = 'activity-info';
+    private const DEFAULT_REFRESH_INTERVAL = 86400; // 24 hours
+
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly SoapClientFactory $soapClientBuilder,
+        private readonly int $refreshInterval = self::DEFAULT_REFRESH_INTERVAL
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     activities: array<string, array{
+     *         id: int,
+     *         name: ?string,
+     *         island: ?string,
+     *         times: ?string,
+     *         startTimeMinutes: ?int,
+     *         transportationMandatory: ?bool,
+     *         description: ?string,
+     *         notes: ?string,
+     *         directions: ?string,
+     *     }>,
+     *     checkedAt: ?int,
+     *     hash: ?string
+     * }
+     */
+    public function getActivityInfo(string $supplierSlug, string $activitySlug): array
+    {
+        $supplierConfig = UtilityService::loadSupplierConfig($supplierSlug);
+        $activityConfig = UtilityService::loadActivityConfig($supplierSlug, $activitySlug);
+
+        $activityIds = $this->extractActivityIds($activityConfig);
+        if ($activityIds === []) {
+            return [
+                'activities' => [],
+                'checkedAt' => null,
+                'hash' => null,
+            ];
+        }
+
+        $cacheKey = CacheKeyGenerator::fromParts(self::CACHE_KEY_PREFIX, $supplierSlug, $activitySlug);
+        $cached = $this->cache->get($cacheKey);
+        $normalizedCache = $this->normalizeCachedPayload($cached, $activityIds);
+
+        if ($normalizedCache !== null && !$this->shouldRefresh($normalizedCache['checkedAt'] ?? null)) {
+            return $normalizedCache;
+        }
+
+        $fresh = $this->attemptRefresh($cacheKey, $supplierConfig, $activityIds, $normalizedCache);
+        if ($fresh !== null) {
+            return $fresh;
+        }
+
+        return $normalizedCache ?? [
+            'activities' => [],
+            'checkedAt' => null,
+            'hash' => null,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed>|null $cached
+     * @param int[] $activityIds
+     */
+    private function normalizeCachedPayload(mixed $cached, array $activityIds): ?array
+    {
+        if (!is_array($cached)) {
+            return null;
+        }
+
+        $activities = [];
+        foreach ($cached['activities'] ?? [] as $key => $value) {
+            $id = $this->resolveActivityIdFromCacheKey($key, $value, $activityIds);
+            if ($id === null || !is_array($value)) {
+                continue;
+            }
+
+            $activities[(string) $id] = $this->formatActivityInfo($id, $value);
+        }
+
+        if ($activities === []) {
+            return null;
+        }
+
+        $checkedAt = null;
+        if (isset($cached['checkedAt']) && is_numeric($cached['checkedAt'])) {
+            $checkedAt = (int) $cached['checkedAt'];
+        }
+
+        $hash = null;
+        if (isset($cached['hash']) && is_string($cached['hash'])) {
+            $hash = $cached['hash'];
+        }
+
+        return [
+            'activities' => $activities,
+            'checkedAt' => $checkedAt,
+            'hash' => $hash,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $supplierConfig
+     * @param int[] $activityIds
+     * @param array<string, mixed>|null $cached
+     */
+    private function attemptRefresh(
+        string $cacheKey,
+        array $supplierConfig,
+        array $activityIds,
+        ?array $cached
+    ): ?array {
+        $freshActivities = $this->fetchActivities($supplierConfig, $activityIds);
+        if ($freshActivities === null) {
+            return null;
+        }
+
+        $payload = $this->buildCachePayload($freshActivities);
+
+        if ($cached !== null && $cached['hash'] !== null && $payload['hash'] === $cached['hash']) {
+            $updated = [
+                'activities' => $cached['activities'],
+                'checkedAt' => $payload['checkedAt'],
+                'hash' => $cached['hash'],
+            ];
+            $this->cache->set($cacheKey, $updated);
+            return $updated;
+        }
+
+        $this->cache->set($cacheKey, $payload);
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $activityConfig
+     * @return int[]
+     */
+    private function extractActivityIds(array $activityConfig): array
+    {
+        $ids = [];
+
+        if (isset($activityConfig['activityId'])) {
+            $ids[] = $activityConfig['activityId'];
+        }
+
+        if (isset($activityConfig['activityIds']) && is_array($activityConfig['activityIds'])) {
+            foreach ($activityConfig['activityIds'] as $id) {
+                $ids[] = $id;
+            }
+        }
+
+        $normalized = [];
+        foreach ($ids as $id) {
+            if (is_numeric($id)) {
+                $normalized[] = (int) $id;
+            }
+        }
+
+        $normalized = array_values(array_unique($normalized));
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>>|null $activities
+     */
+    private function buildCachePayload(?array $activities): array
+    {
+        $activities = $activities ?? [];
+        $normalized = [];
+
+        foreach ($activities as $id => $activity) {
+            if (!is_array($activity)) {
+                continue;
+            }
+
+            $normalized[(string) $id] = $this->formatActivityInfo((int) $id, $activity);
+        }
+
+        return [
+            'activities' => $normalized,
+            'checkedAt' => time(),
+            'hash' => $this->hashActivities($normalized),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $supplierConfig
+     * @param int[] $activityIds
+     * @return array<int, array<string, mixed>>|null
+     */
+    private function fetchActivities(array $supplierConfig, array $activityIds): ?array
+    {
+        try {
+            $client = $this->soapClientBuilder->build();
+        } catch (Throwable) {
+            return null;
+        }
+
+        $activities = [];
+
+        foreach ($activityIds as $activityId) {
+            $payload = [
+                'serviceLogin' => [
+                    'username' => $supplierConfig['soapCredentials']['username'] ?? '',
+                    'password' => $supplierConfig['soapCredentials']['password'] ?? '',
+                ],
+                'supplierId' => isset($supplierConfig['supplierId']) ? (int) $supplierConfig['supplierId'] : null,
+                'activityId' => $activityId,
+            ];
+
+            try {
+                $response = $client->__soapCall('getActivity', [$payload]);
+            } catch (SoapFault) {
+                continue;
+            }
+
+            $data = $this->normalizeActivityResponse($response);
+            if ($data === null) {
+                continue;
+            }
+
+            $activities[$activityId] = $data;
+        }
+
+        return $activities;
+    }
+
+    private function shouldRefresh(?int $checkedAt): bool
+    {
+        if ($checkedAt === null) {
+            return true;
+        }
+
+        if ($this->refreshInterval <= 0) {
+            return true;
+        }
+
+        return (time() - $checkedAt) >= $this->refreshInterval;
+    }
+
+    private function hashActivities(array $activities): string
+    {
+        try {
+            return hash('sha256', json_encode($activities, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE));
+        } catch (JsonException) {
+            return hash('sha256', serialize($activities));
+        }
+    }
+
+    private function normalizeActivityResponse(mixed $response): ?array
+    {
+        if (is_object($response) && property_exists($response, 'return')) {
+            $response = $response->return;
+        }
+
+        if ($response instanceof SoapClient) {
+            return null;
+        }
+
+        if (is_object($response)) {
+            try {
+                $response = json_decode(json_encode($response, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                return null;
+            }
+        }
+
+        if (!is_array($response)) {
+            return null;
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function formatActivityInfo(int $activityId, array $payload): array
+    {
+        return [
+            'id' => $activityId,
+            'name' => $this->extractString($payload, ['name', 'activityName', 'title']),
+            'island' => $this->extractString($payload, ['island']),
+            'times' => $this->extractString($payload, ['times', 'timesLabel', 'time', 'timeLabel']),
+            'startTimeMinutes' => $this->extractInt($payload, ['startTimeMinutes', 'starttime']),
+            'transportationMandatory' => $this->extractBool($payload, ['transportationMandatory', 'transportation_required']),
+            'description' => $this->extractString($payload, ['description', 'details']),
+            'notes' => $this->extractString($payload, ['notes', 'additionalNotes']),
+            'directions' => $this->extractString($payload, ['directions', 'directionsInfo']),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param string[] $keys
+     */
+    private function extractString(array $payload, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $payload)) {
+                continue;
+            }
+
+            $value = $payload[$key];
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_string($value)) {
+                $trimmed = trim($value);
+                if ($trimmed === '') {
+                    continue;
+                }
+                return $trimmed;
+            }
+
+            if (is_numeric($value)) {
+                return (string) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param string[] $keys
+     */
+    private function extractInt(array $payload, array $keys): ?int
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $payload)) {
+                continue;
+            }
+
+            $value = $payload[$key];
+            if (is_int($value)) {
+                return $value;
+            }
+
+            if (is_numeric($value)) {
+                return (int) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param string[] $keys
+     */
+    private function extractBool(array $payload, array $keys): ?bool
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $payload)) {
+                continue;
+            }
+
+            $value = $payload[$key];
+            if (is_bool($value)) {
+                return $value;
+            }
+
+            if (is_numeric($value)) {
+                return ((int) $value) === 1;
+            }
+
+            if (is_string($value)) {
+                $normalized = strtolower(trim($value));
+                if ($normalized === '') {
+                    continue;
+                }
+
+                if (in_array($normalized, ['1', 'true', 'yes', 'y', 'required'], true)) {
+                    return true;
+                }
+
+                if (in_array($normalized, ['0', 'false', 'no', 'n'], true)) {
+                    return false;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed $value
+     * @param int[] $activityIds
+     */
+    private function resolveActivityIdFromCacheKey(mixed $key, mixed $value, array $activityIds): ?int
+    {
+        if (is_numeric($key)) {
+            $candidate = (int) $key;
+            if (in_array($candidate, $activityIds, true)) {
+                return $candidate;
+            }
+        }
+
+        if (is_array($value) && isset($value['id']) && is_numeric($value['id'])) {
+            return (int) $value['id'];
+        }
+
+        foreach ($activityIds as $id) {
+            if ((string) $key === (string) $id) {
+                return $id;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/phpunit/Services/ActivityInfoServiceTest.php
+++ b/tests/phpunit/Services/ActivityInfoServiceTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PonoRez\SGCForms\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use PonoRez\SGCForms\Cache\CacheInterface;
+use PonoRez\SGCForms\Services\ActivityInfoService;
+use PonoRez\SGCForms\Services\SoapClientFactory;
+use PonoRez\SGCForms\UtilityService;
+use RuntimeException;
+use SoapClient;
+
+final class ActivityInfoServiceTest extends TestCase
+{
+    private const SUPPLIER_SLUG = 'supplier-slug';
+    private const ACTIVITY_SLUG = 'activity-info-test';
+
+    private string $configPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $supplierDir = UtilityService::supplierDirectory(self::SUPPLIER_SLUG);
+        if (!is_dir($supplierDir)) {
+            $this->markTestSkipped('Supplier fixtures not available.');
+        }
+
+        $this->configPath = $supplierDir . '/' . self::ACTIVITY_SLUG . '.config';
+
+        $config = [
+            'activityId' => 369,
+            'activityIds' => [369, 555],
+        ];
+
+        file_put_contents($this->configPath, json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->configPath) && file_exists($this->configPath)) {
+            @unlink($this->configPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testFetchesAllActivitiesAndCachesResult(): void
+    {
+        $responses = [
+            369 => [
+                'name' => 'Morning Tour',
+                'island' => 'Kauai',
+                'times' => '8:00 AM Departure',
+                'description' => "Line one\nLine two",
+                'notes' => 'Remember sunscreen',
+                'directions' => 'Harbor entrance',
+            ],
+            555 => [
+                'name' => 'Afternoon Tour',
+                'times' => '1:00 PM Departure',
+            ],
+        ];
+
+        $cache = new InMemoryCache();
+        $client = new ActivityInfoRecordingSoapClient($responses);
+        $factory = new ActivityInfoStubSoapClientFactory($client);
+
+        $service = new ActivityInfoService($cache, $factory);
+        $result = $service->getActivityInfo(self::SUPPLIER_SLUG, self::ACTIVITY_SLUG);
+
+        self::assertSame(2, count($client->calls));
+        self::assertArrayHasKey('369', $result['activities']);
+        self::assertArrayHasKey('555', $result['activities']);
+        self::assertSame('Kauai', $result['activities']['369']['island']);
+        self::assertSame('8:00 AM Departure', $result['activities']['369']['times']);
+        self::assertSame('Remember sunscreen', $result['activities']['369']['notes']);
+        self::assertNotNull($result['checkedAt']);
+        self::assertIsString($result['hash']);
+
+        $cachePayload = $cache->get('activity-info:supplier-slug:activity-info-test');
+        self::assertIsArray($cachePayload);
+        self::assertArrayHasKey('activities', $cachePayload);
+
+        $client->calls = [];
+        $again = $service->getActivityInfo(self::SUPPLIER_SLUG, self::ACTIVITY_SLUG);
+        self::assertSame([], $client->calls, 'Expected subsequent call to use cached payload.');
+        self::assertSame($result['hash'], $again['hash']);
+    }
+
+    public function testRefreshesCacheWhenHashChanges(): void
+    {
+        $responses = [
+            369 => [
+                'name' => 'Morning Tour',
+                'description' => 'Initial description',
+            ],
+            555 => [
+                'name' => 'Afternoon Tour',
+            ],
+        ];
+
+        $cache = new InMemoryCache();
+        $client = new ActivityInfoRecordingSoapClient($responses);
+        $factory = new ActivityInfoStubSoapClientFactory($client);
+
+        $service = new ActivityInfoService($cache, $factory, 0);
+        $initial = $service->getActivityInfo(self::SUPPLIER_SLUG, self::ACTIVITY_SLUG);
+        self::assertSame('Initial description', $initial['activities']['369']['description']);
+        self::assertSame(2, count($client->calls));
+
+        $client->responses[369]['description'] = 'Updated description';
+        $client->calls = [];
+
+        $updated = $service->getActivityInfo(self::SUPPLIER_SLUG, self::ACTIVITY_SLUG);
+        self::assertSame('Updated description', $updated['activities']['369']['description']);
+        self::assertNotSame($initial['hash'], $updated['hash']);
+        self::assertGreaterThan(0, count($client->calls));
+    }
+}
+
+final class InMemoryCache implements CacheInterface
+{
+    /** @var array<string, mixed> */
+    public array $storage = [];
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->storage[$key] ?? $default;
+    }
+
+    public function set(string $key, mixed $value, int $ttl = 0): void
+    {
+        $this->storage[$key] = $value;
+    }
+
+    public function delete(string $key): void
+    {
+        unset($this->storage[$key]);
+    }
+}
+
+final class ActivityInfoStubSoapClientFactory implements SoapClientFactory
+{
+    public function __construct(private SoapClient $client)
+    {
+    }
+
+    public function build(): SoapClient
+    {
+        return $this->client;
+    }
+}
+
+final class ActivityInfoRecordingSoapClient extends SoapClient
+{
+    /** @var array<int, array<string, mixed>> */
+    public array $responses;
+
+    /** @var list<array{0:string,1:array}> */
+    public array $calls = [];
+
+    /**
+     * @param array<int, array<string, mixed>> $responses
+     */
+    public function __construct(array $responses)
+    {
+        $this->responses = $responses;
+        // Skip parent constructor; responses are pre-baked for tests.
+    }
+
+    public function __soapCall(string $name, array $arguments, ?array $options = null, mixed $inputHeaders = null, mixed &$outputHeaders = null): mixed
+    {
+        $this->calls[] = [$name, $arguments];
+
+        if ($name !== 'getActivity') {
+            throw new RuntimeException(sprintf('Unexpected SOAP call to "%s".', $name));
+        }
+
+        $payload = $arguments[0] ?? [];
+        $activityId = $payload['activityId'] ?? null;
+        if (!is_int($activityId)) {
+            throw new RuntimeException('Missing activityId in payload.');
+        }
+
+        if (!isset($this->responses[$activityId])) {
+            throw new RuntimeException(sprintf('No fixture for activity %d.', $activityId));
+        }
+
+        return (object) ['return' => (object) $this->responses[$activityId]];
+    }
+}


### PR DESCRIPTION
## Summary
- add an ActivityInfoService that caches getActivity results for all configured activity IDs and refreshes them when the payload changes
- populate bootstrap activity details and departure labels, and enrich availability metadata with the cached activity info
- cover the new service with PHPUnit tests exercising cache priming and refresh behaviour

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68deb0c4aa588329a9d98c993a89a1a6