### PR TITLE
Remove availability metadata debug output

### DIFF
--- a/partials/form/component-timeslot.php
+++ b/partials/form/component-timeslot.php
@@ -30,7 +30,6 @@ $timeslotEndpoint = $apiEndpoints['availability'] ?? null;
         <ul class="hidden divide-y divide-slate-200" data-timeslot-list role="radiogroup">
             <!-- Timeslots injected by JavaScript -->
         </ul>
-        <div class="hidden border-t border-slate-200 bg-slate-50 px-4 py-3 text-xs font-mono text-slate-600 whitespace-pre-wrap break-words" data-availability-metadata></div>
     </div>
 
     <?php if ($timeslotEndpoint): ?>


### PR DESCRIPTION
## Summary
- remove the availability metadata JSON panel from the departure time list template
- strip the availability module of metadata debug rendering logic and associated helper functions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deb6bf795c8329903690a42f14a5e3