### PR TITLE
Remove availability metadata debug panel

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -7,6 +7,12 @@ import { initUpgrades } from './modules/upgrades.js';
 import { initPricing } from './modules/pricing.js';
 import { initBooking } from './modules/booking.js';
 
+function removeAvailabilityMetadataDebug() {
+    document.querySelectorAll('[data-availability-metadata]').forEach((element) => {
+        element.remove();
+    });
+}
+
 function bootstrap() {
     initAlerts();
     initGuestTypes();
@@ -16,6 +22,7 @@ function bootstrap() {
     initUpgrades();
     initPricing();
     initBooking();
+    removeAvailabilityMetadataDebug();
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- remove the availability metadata debug element from the UI by stripping any data-availability-metadata nodes after bootstrap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68debb27d1588329a45dad5f1e0dc98a