### PR TITLE
Remove ponorez metadata source from availability response

### DIFF
--- a/controller/Services/AvailabilityService.php
+++ b/controller/Services/AvailabilityService.php
@@ -192,15 +192,14 @@ final class AvailabilityService
             'calendar' => $calendar,
             'timeslots' => $timeslots,
             'metadata' => array_filter([
-            'source' => 'ponorez-json',
-            'requestedSeats' => $requestedSeats,
-            'firstAvailableDate' => $firstAvailableDate,
-            'timeslotStatus' => $timeslotStatus,
-            'selectedDateStatus' => $selectedDayStatus,
-            'month' => $viewMonthKey,
-            'certificateVerification' => $this->certificateVerificationDisabled ? 'disabled' : 'verified',
-            'extended' => $extendedAvailability,
-        ], static fn ($value) => $value !== null),
+                'requestedSeats' => $requestedSeats,
+                'firstAvailableDate' => $firstAvailableDate,
+                'timeslotStatus' => $timeslotStatus,
+                'selectedDateStatus' => $selectedDayStatus,
+                'month' => $viewMonthKey,
+                'certificateVerification' => $this->certificateVerificationDisabled ? 'disabled' : 'verified',
+                'extended' => $extendedAvailability,
+            ], static fn ($value) => $value !== null),
         ];
     }
 

--- a/tests/phpunit/Services/AvailabilityTest.php
+++ b/tests/phpunit/Services/AvailabilityTest.php
@@ -96,7 +96,7 @@ final class AvailabilityTest extends TestCase
         ], $timeslots[0]->getDetails());
 
         $metadata = $result['metadata'];
-        self::assertSame('ponorez-json', $metadata['source']);
+        self::assertArrayNotHasKey('source', $metadata);
         self::assertSame(2, $metadata['requestedSeats']);
         self::assertSame('available', $metadata['selectedDateStatus']);
         self::assertSame('available', $metadata['timeslotStatus']);


### PR DESCRIPTION
## Summary
- remove the ponorez-json metadata source entry from the availability response payload
- update the availability service test to reflect the absence of the metadata source field

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68ded4d55a6c8329b9e3929aa06497bc