### PR TITLE
Add SOAP availability probing flow for timeslot messaging

### DIFF
--- a/api/get-availability-messages.php
+++ b/api/get-availability-messages.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../controller/Setup.php';
+
+use PonoRez\SGCForms\Services\AvailabilityMessagingService;
+use PonoRez\SGCForms\Services\SoapClientBuilder;
+use PonoRez\SGCForms\Support\ErrorHandler;
+use PonoRez\SGCForms\Support\RequestValidator;
+use PonoRez\SGCForms\Support\ResponseFormatter;
+
+try {
+    $params = RequestValidator::requireParams($_GET, ['supplier', 'activity']);
+
+    $guestCounts = [];
+    if (isset($_GET['guestCounts'])) {
+        $guestCounts = RequestValidator::optionalJson((string) $_GET['guestCounts'], 'guestCounts');
+    }
+
+    $timeslotRequests = [];
+    if (isset($_GET['timeslots'])) {
+        $rawTimeslots = $_GET['timeslots'];
+        if (is_string($rawTimeslots)) {
+            $decoded = RequestValidator::optionalJson($rawTimeslots, 'timeslots');
+            if (is_array($decoded)) {
+                $timeslotRequests = $decoded;
+            }
+        } elseif (is_array($rawTimeslots)) {
+            $timeslotRequests = $rawTimeslots;
+        }
+    }
+
+    $date = isset($_GET['date']) ? trim((string) $_GET['date']) : '';
+
+    if ($timeslotRequests === []) {
+        $activityIds = [];
+
+        if (isset($_GET['activityIds'])) {
+            $rawActivityIds = $_GET['activityIds'];
+            if (is_string($rawActivityIds)) {
+                $trimmed = trim($rawActivityIds);
+                if ($trimmed !== '') {
+                    if ($trimmed[0] === '[') {
+                        $decoded = RequestValidator::optionalJson($trimmed, 'activityIds');
+                        if (is_array($decoded)) {
+                            $activityIds = $decoded;
+                        }
+                    } else {
+                        $activityIds = array_filter(array_map('trim', explode(',', $trimmed)), static fn ($value) => $value !== '');
+                    }
+                }
+            } elseif (is_array($rawActivityIds)) {
+                $activityIds = $rawActivityIds;
+            }
+        }
+
+        if ($activityIds === []) {
+            throw new \InvalidArgumentException('At least one activityId must be provided.');
+        }
+
+        if ($date === '') {
+            throw new \InvalidArgumentException('Parameter "date" is required when timeslots are not provided.');
+        }
+
+        foreach ($activityIds as $activityId) {
+            $timeslotRequests[] = [
+                'activityId' => $activityId,
+                'date' => $date,
+            ];
+        }
+    }
+
+    $service = new AvailabilityMessagingService(new SoapClientBuilder());
+    $result = $service->probeTimeslots(
+        (string) $params['supplier'],
+        (string) $params['activity'],
+        $timeslotRequests,
+        is_array($guestCounts) ? $guestCounts : []
+    );
+
+    ResponseFormatter::success([
+        'messages' => $result['messages'],
+        'metadata' => [
+            'requestedSeats' => $result['requestedSeats'],
+        ],
+    ]);
+} catch (\Throwable $exception) {
+    ErrorHandler::handle($exception);
+}

--- a/assets/js/core/store.js
+++ b/assets/js/core/store.js
@@ -53,6 +53,7 @@ function normaliseUpgradeQuantities(upgrades) {
 
 const guestCounts = normaliseGuestCounts(bootstrap.activity && bootstrap.activity.guestTypes);
 const upgradeQuantities = normaliseUpgradeQuantities(bootstrap.activity && bootstrap.activity.upgrades);
+const initialGuestSignature = JSON.stringify(guestCounts);
 
 const initialState = {
     bootstrap,
@@ -75,6 +76,8 @@ const initialState = {
     timeslots: [],
     selectedTimeslotId: null,
     availabilityMetadata: {},
+    timeslotMessages: {},
+    timeslotMessagesSignature: initialGuestSignature,
     transportationRouteId: bootstrap.activity
         && bootstrap.activity.transportation
         && bootstrap.activity.transportation.defaultRouteId

--- a/assets/js/modules/availability.js
+++ b/assets/js/modules/availability.js
@@ -15,6 +15,10 @@ let fetchTimer;
 let controller;
 let lastSignature = null;
 let lastVisibleMonth;
+let messageFetchTimer;
+let messageController;
+let lastMessageSignature = null;
+let lastGuestSignature = null;
 
 function normaliseId(value) {
     if (value === null || value === undefined) {
@@ -851,8 +855,11 @@ function mapTimeslots(timeslots = []) {
             ? Number(slot.available)
             : null;
         const details = normaliseTimeslotDetails(slot.details);
+        const availabilityTier = typeof slot.availabilityTier === 'string'
+            ? String(slot.availabilityTier).toLowerCase()
+            : null;
 
-        accumulator.push({ id, label, available, details });
+        accumulator.push({ id, label, available, details, availabilityTier });
         return accumulator;
     }, []);
 }
@@ -886,6 +893,127 @@ function buildAvailabilityUrl() {
     return url.toString();
 }
 
+function buildAvailabilityMessageUrl(date, activityIds, guestCounts) {
+    const base = resolveApiUrl('availabilityMessages');
+    if (!base) {
+        return null;
+    }
+
+    const url = new URL(base);
+
+    if (typeof date === 'string' && date !== '') {
+        url.searchParams.set('date', date);
+    }
+
+    if (Array.isArray(activityIds) && activityIds.length > 0) {
+        const normalisedIds = activityIds
+            .map((id) => normaliseId(id))
+            .filter((id) => id !== null);
+        if (normalisedIds.length > 0) {
+            url.searchParams.set('activityIds', JSON.stringify(normalisedIds));
+        }
+    }
+
+    if (guestCounts && typeof guestCounts === 'object') {
+        const entries = Object.entries(guestCounts)
+            .filter(([, value]) => Number(value) > 0);
+        if (entries.length > 0) {
+            url.searchParams.set('guestCounts', JSON.stringify(Object.fromEntries(entries)));
+        }
+    }
+
+    return url.toString();
+}
+
+function normalizeMessageEntry(entry, fallbackDate, keyHint) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const candidateId = entry.activityId ?? entry.activityid ?? entry.id ?? keyHint;
+    const activityId = normaliseId(candidateId);
+    if (activityId === null) {
+        return null;
+    }
+
+    let date = fallbackDate || null;
+    if (typeof entry.date === 'string' && entry.date.trim() !== '') {
+        const trimmed = entry.date.trim();
+        date = trimmed.length >= 10 ? trimmed.slice(0, 10) : trimmed;
+    }
+
+    const tier = typeof entry.tier === 'string'
+        ? entry.tier.toLowerCase()
+        : null;
+
+    let seats = null;
+    if (entry.seats !== undefined && entry.seats !== null) {
+        const numeric = Number(entry.seats);
+        seats = Number.isFinite(numeric) ? numeric : null;
+    }
+
+    return {
+        activityId,
+        date: date || fallbackDate || '',
+        tier,
+        seats,
+    };
+}
+
+function normalizeMessagesPayload(messages, fallbackDate) {
+    const normalized = {};
+
+    const assign = (entry, keyHint) => {
+        const normalizedEntry = normalizeMessageEntry(entry, fallbackDate, keyHint);
+        if (!normalizedEntry) {
+            return;
+        }
+
+        normalized[normalizedEntry.activityId] = normalizedEntry;
+    };
+
+    if (Array.isArray(messages)) {
+        messages.forEach((entry) => assign(entry));
+        return normalized;
+    }
+
+    if (messages && typeof messages === 'object') {
+        Object.entries(messages).forEach(([key, value]) => {
+            assign(value, key);
+        });
+    }
+
+    return normalized;
+}
+
+function resetAvailabilityMessages(signature) {
+    if (messageController) {
+        messageController.abort();
+        messageController = null;
+    }
+
+    window.clearTimeout(messageFetchTimer);
+    messageFetchTimer = null;
+    lastMessageSignature = null;
+
+    setState((current) => {
+        const updates = {
+            timeslotMessagesSignature: signature,
+            timeslotMessages: {},
+        };
+
+        if (Array.isArray(current.timeslots) && current.timeslots.length > 0) {
+            updates.timeslots = current.timeslots.map((slot) => ({
+                ...slot,
+                availabilityTier: null,
+                available: null,
+            }));
+        }
+
+        return updates;
+    });
+}
+
 function setLoading(isLoading) {
     setState((current) => ({
         loading: { ...current.loading, availability: isLoading },
@@ -893,19 +1021,230 @@ function setLoading(isLoading) {
 }
 
 function describeAvailability(timeslot) {
+    const tier = typeof timeslot.availabilityTier === 'string'
+        ? timeslot.availabilityTier.toLowerCase()
+        : null;
+
+    if (tier === 'unavailable') {
+        return 'Sold out';
+    }
+
+    if (tier === 'limited') {
+        const seats = Number(timeslot.available);
+        if (Number.isFinite(seats) && seats > 0) {
+            return `Only ${seats} ${pluralize('spot', seats)} left`;
+        }
+        return 'Limited availability';
+    }
+
+    if (tier === 'plenty') {
+        return 'Available';
+    }
+
     if (timeslot.available === null || timeslot.available === undefined) {
         return 'Availability will be confirmed during checkout.';
     }
 
-    if (timeslot.available <= 0) {
+    const seats = Number(timeslot.available);
+    if (!Number.isFinite(seats) || seats <= 0) {
         return 'Sold out';
     }
 
-    if (timeslot.available <= 4) {
-        return `${timeslot.available} ${pluralize('spot', timeslot.available)} left`;
+    if (seats <= 4) {
+        return `${seats} ${pluralize('spot', seats)} left`;
     }
 
-    return `${timeslot.available} seats available`;
+    return `${seats} seats available`;
+}
+
+async function fetchAvailabilityMessages() {
+    const state = getState();
+
+    if (state.loading?.availability) {
+        return;
+    }
+
+    const date = state.selectedDate;
+    const timeslots = Array.isArray(state.timeslots) ? state.timeslots : [];
+
+    if (!date || timeslots.length === 0) {
+        return;
+    }
+
+    const guestCounts = state.guestCounts || {};
+    const guestSignature = JSON.stringify(guestCounts);
+
+    if (state.timeslotMessagesSignature !== guestSignature) {
+        resetAvailabilityMessages(guestSignature);
+        return;
+    }
+
+    const messagesForDate = state.timeslotMessages?.[date] || {};
+    const missingIds = [];
+
+    timeslots.forEach((slot) => {
+        const id = normaliseId(slot?.id);
+        if (id === null) {
+            return;
+        }
+
+        if (!messagesForDate[id]) {
+            missingIds.push(id);
+        }
+    });
+
+    if (missingIds.length === 0) {
+        return;
+    }
+
+    const url = buildAvailabilityMessageUrl(date, missingIds, guestCounts);
+    if (!url) {
+        return;
+    }
+
+    const signature = JSON.stringify({
+        date,
+        ids: [...missingIds].sort(),
+        guests: guestSignature,
+    });
+
+    if (signature === lastMessageSignature) {
+        return;
+    }
+
+    if (messageController) {
+        messageController.abort();
+    }
+
+    messageController = new AbortController();
+    lastMessageSignature = signature;
+
+    try {
+        const payload = await requestJson(url, { signal: messageController.signal });
+        const normalized = normalizeMessagesPayload(payload?.messages, date);
+        const metadata = payload?.metadata || {};
+        const requestedSeatsValue = Number(metadata.requestedSeats);
+        const requestedSeats = Number.isFinite(requestedSeatsValue) ? requestedSeatsValue : null;
+
+        setState((current) => {
+            const currentSignature = JSON.stringify(current.guestCounts || {});
+            if (currentSignature !== guestSignature) {
+                return {};
+            }
+
+            const nextMessages = { ...current.timeslotMessages };
+            const existingForDate = nextMessages[date] ? { ...nextMessages[date] } : {};
+            let changed = false;
+
+            Object.values(normalized).forEach((entry) => {
+                if (!entry) {
+                    return;
+                }
+
+                existingForDate[entry.activityId] = entry;
+                changed = true;
+            });
+
+            if (changed) {
+                nextMessages[date] = existingForDate;
+            }
+
+            const updates = {
+                timeslotMessagesSignature: guestSignature,
+            };
+
+            if (changed) {
+                updates.timeslotMessages = nextMessages;
+            }
+
+            if (current.selectedDate === date && changed) {
+                const updatedTimeslots = current.timeslots.map((slot) => {
+                    const id = normaliseId(slot?.id);
+                    if (id === null) {
+                        return slot;
+                    }
+
+                    const entry = existingForDate[id];
+                    if (!entry) {
+                        return slot;
+                    }
+
+                    const numericSeats = Number(entry.seats);
+                    const seats = Number.isFinite(numericSeats) ? numericSeats : null;
+
+                    return {
+                        ...slot,
+                        availabilityTier: entry.tier || null,
+                        available: seats,
+                    };
+                });
+
+                updates.timeslots = updatedTimeslots;
+
+                const selectedId = normaliseId(current.selectedTimeslotId);
+                if (selectedId !== null) {
+                    const selectedEntry = existingForDate[selectedId];
+                    const selectedSeats = Number(selectedEntry?.seats);
+                    const selectedTier = selectedEntry?.tier ? String(selectedEntry.tier).toLowerCase() : null;
+                    const selectedUnavailable = Boolean(selectedTier === 'unavailable'
+                        || (Number.isFinite(selectedSeats) && selectedSeats <= 0));
+
+                    if (selectedUnavailable) {
+                        const fallback = updatedTimeslots.find((slot) => {
+                            if (!slot) {
+                                return false;
+                            }
+
+                            const tier = typeof slot.availabilityTier === 'string'
+                                ? slot.availabilityTier.toLowerCase()
+                                : null;
+
+                            if (tier === 'unavailable') {
+                                return false;
+                            }
+
+                            if (slot.available === null || slot.available === undefined) {
+                                return true;
+                            }
+
+                            return Number(slot.available) > 0;
+                        });
+
+                        updates.selectedTimeslotId = fallback ? fallback.id : null;
+                    }
+                }
+            }
+
+            if (requestedSeats !== null) {
+                updates.availabilityMetadata = {
+                    ...current.availabilityMetadata,
+                    requestedSeats,
+                };
+            }
+
+            return updates;
+        });
+    } catch (error) {
+        if (error?.name !== 'AbortError') {
+            console.error('Availability message request failed', error);
+        }
+    } finally {
+        lastMessageSignature = null;
+        if (messageController) {
+            messageController = null;
+        }
+    }
+}
+
+function scheduleMessageFetch({ immediate = false } = {}) {
+    window.clearTimeout(messageFetchTimer);
+
+    if (immediate) {
+        fetchAvailabilityMessages();
+        return;
+    }
+
+    messageFetchTimer = window.setTimeout(fetchAvailabilityMessages, 150);
 }
 
 function renderTimeslots(state) {
@@ -951,7 +1290,12 @@ function renderTimeslots(state) {
                 radio.checked = true;
             }
 
-            if (timeslot.available !== null && timeslot.available <= 0) {
+            const normalizedTier = typeof timeslot.availabilityTier === 'string'
+                ? timeslot.availabilityTier.toLowerCase()
+                : null;
+
+            if (normalizedTier === 'unavailable'
+                || (timeslot.available !== null && timeslot.available <= 0)) {
                 radio.disabled = true;
             }
 
@@ -1116,16 +1460,29 @@ export function initAvailability() {
 
     subscribe((state) => {
         const visibleMonthChanged = lastVisibleMonth && state.visibleMonth !== lastVisibleMonth;
+        const guestSignature = JSON.stringify(state.guestCounts || {});
+
+        if (state.timeslotMessagesSignature !== guestSignature) {
+            lastGuestSignature = guestSignature;
+            resetAvailabilityMessages(guestSignature);
+            return;
+        }
+
+        lastGuestSignature = guestSignature;
 
         renderTimeslots(state);
 
         lastVisibleMonth = state.visibleMonth;
 
         scheduleFetch({ immediate: Boolean(visibleMonthChanged) });
+        scheduleMessageFetch();
     });
 
-    lastVisibleMonth = getState().visibleMonth;
+    const initialState = getState();
+    lastVisibleMonth = initialState.visibleMonth;
+    lastGuestSignature = JSON.stringify(initialState.guestCounts || {});
     scheduleFetch();
+    scheduleMessageFetch();
 }
 
 export default initAvailability;

--- a/controller/Services/AvailabilityMessagingService.php
+++ b/controller/Services/AvailabilityMessagingService.php
@@ -1,0 +1,350 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PonoRez\SGCForms\Services;
+
+use DateTimeImmutable;
+use PonoRez\SGCForms\UtilityService;
+use RuntimeException;
+use SoapClient;
+use SoapFault;
+use stdClass;
+use Throwable;
+
+final class AvailabilityMessagingService
+{
+    private const PROBE_OFFSETS = [3, 2, 1];
+
+    public function __construct(private readonly SoapClientFactory $soapClientBuilder)
+    {
+    }
+
+    /**
+     * @param array<int|string, int> $guestCounts
+     * @param array<int, array{activityId:int|string,date:string}>|array<int, array<string, mixed>>|array<int, mixed> $timeslotRequests
+     *
+     * @return array{requestedSeats:int,messages:list<array{activityId:string,date:string,tier:string,seats:?int}>}
+     */
+    public function probeTimeslots(
+        string $supplierSlug,
+        string $activitySlug,
+        array $timeslotRequests,
+        array $guestCounts = []
+    ): array {
+        $supplierConfig = UtilityService::loadSupplierConfig($supplierSlug);
+        $activityConfig = UtilityService::loadActivityConfig($supplierSlug, $activitySlug);
+
+        $requestedSeats = $this->calculateRequestedSeats($guestCounts, $activityConfig);
+        $activityIds = $this->extractActivityIds($activityConfig);
+        $normalizedRequests = $this->normalizeTimeslotRequests($timeslotRequests, $activityIds);
+
+        if ($normalizedRequests === []) {
+            return [
+                'requestedSeats' => $requestedSeats,
+                'messages' => [],
+            ];
+        }
+
+        try {
+            $client = $this->soapClientBuilder->build();
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Unable to build SOAP client for availability probing.', 0, $exception);
+        }
+
+        $results = [];
+        $cache = [];
+
+        foreach ($normalizedRequests as $request) {
+            $cacheKey = $this->buildCacheKey($request['activityId'], $request['date'], $requestedSeats);
+            if (isset($cache[$cacheKey])) {
+                $results[] = $cache[$cacheKey];
+                continue;
+            }
+
+            $baseline = $this->callCheckActivityAvailability(
+                $client,
+                $supplierConfig,
+                $request['activityId'],
+                $request['date'],
+                $requestedSeats
+            );
+
+            if ($baseline !== true) {
+                $message = [
+                    'activityId' => (string) $request['activityId'],
+                    'date' => $request['date'],
+                    'tier' => 'unavailable',
+                    'seats' => 0,
+                ];
+                $cache[$cacheKey] = $message;
+                $results[] = $message;
+                continue;
+            }
+
+            $message = $this->probeAdditionalAvailability(
+                $client,
+                $supplierConfig,
+                $request['activityId'],
+                $request['date'],
+                $requestedSeats
+            );
+
+            $cache[$cacheKey] = $message;
+            $results[] = $message;
+        }
+
+        return [
+            'requestedSeats' => $requestedSeats,
+            'messages' => $results,
+        ];
+    }
+
+    private function buildCacheKey(int $activityId, string $date, int $requestedSeats): string
+    {
+        return sprintf('%s|%d|%d', $date, $activityId, $requestedSeats);
+    }
+
+    /**
+     * @param array<string, mixed> $activityConfig
+     */
+    private function calculateRequestedSeats(array $guestCounts, array $activityConfig): int
+    {
+        $total = 0;
+        foreach ($guestCounts as $count) {
+            $total += max(0, (int) $count);
+        }
+
+        if ($total > 0) {
+            return $total;
+        }
+
+        $minimums = 0;
+        foreach ($activityConfig['minGuestCount'] ?? [] as $min) {
+            $minimums += max(0, (int) $min);
+        }
+
+        return max($minimums, 1);
+    }
+
+    /**
+     * @param array<int|string, int> $activityIds
+     * @return list<array{activityId:int,date:string}>
+     */
+    private function normalizeTimeslotRequests(array $timeslotRequests, array $activityIds): array
+    {
+        $allowed = $activityIds !== [] ? array_flip($activityIds) : null;
+
+        $normalized = [];
+        $seen = [];
+
+        foreach ($timeslotRequests as $entry) {
+            if (is_array($entry)) {
+                $activityId = $entry['activityId'] ?? $entry['activityid'] ?? $entry['id'] ?? null;
+                $date = $entry['date'] ?? null;
+            } else {
+                $activityId = null;
+                $date = null;
+            }
+
+            $normalizedId = $this->normalizeActivityId($activityId);
+            if ($normalizedId === null) {
+                continue;
+            }
+
+            if ($allowed !== null && !isset($allowed[$normalizedId])) {
+                continue;
+            }
+
+            $normalizedDate = $this->normalizeIsoDate($date);
+            if ($normalizedDate === null) {
+                continue;
+            }
+
+            $key = $normalizedDate . '|' . $normalizedId;
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $normalized[] = [
+                'activityId' => $normalizedId,
+                'date' => $normalizedDate,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeActivityId(mixed $activityId): ?int
+    {
+        if (is_int($activityId)) {
+            return $activityId;
+        }
+
+        if (is_string($activityId) && $activityId !== '' && preg_match('/^-?\d+$/', $activityId) === 1) {
+            return (int) $activityId;
+        }
+
+        return null;
+    }
+
+    private function normalizeIsoDate(mixed $date): ?string
+    {
+        if (!is_string($date) || trim($date) === '') {
+            return null;
+        }
+
+        try {
+            $parsed = new DateTimeImmutable($date);
+        } catch (\Exception) {
+            return null;
+        }
+
+        return $parsed->format('Y-m-d');
+    }
+
+    /**
+     * @param array<string, mixed> $supplierConfig
+     */
+    private function callCheckActivityAvailability(
+        SoapClient $client,
+        array $supplierConfig,
+        int $activityId,
+        string $isoDate,
+        int $requestedSeats
+    ): ?bool {
+        $payload = [
+            'serviceLogin' => [
+                'username' => $supplierConfig['soapCredentials']['username'] ?? '',
+                'password' => $supplierConfig['soapCredentials']['password'] ?? '',
+            ],
+            'activityId' => $activityId,
+            'date' => $this->formatSoapDate($isoDate),
+            'requestedAvailability' => max(0, $requestedSeats),
+        ];
+
+        if (isset($supplierConfig['supplierId'])) {
+            $payload['supplierId'] = (int) $supplierConfig['supplierId'];
+        }
+
+        try {
+            $response = $client->__soapCall('checkActivityAvailability', [$payload]);
+        } catch (SoapFault) {
+            return null;
+        }
+
+        return $this->normalizeBooleanResponse($response);
+    }
+
+    private function probeAdditionalAvailability(
+        SoapClient $client,
+        array $supplierConfig,
+        int $activityId,
+        string $isoDate,
+        int $requestedSeats
+    ): array {
+        $confirmedSeats = $requestedSeats;
+        $tier = 'limited';
+
+        foreach (self::PROBE_OFFSETS as $offset) {
+            $probeSeats = $requestedSeats + $offset;
+            $available = $this->callCheckActivityAvailability(
+                $client,
+                $supplierConfig,
+                $activityId,
+                $isoDate,
+                $probeSeats
+            );
+
+            if ($available === true) {
+                $confirmedSeats = $probeSeats;
+                $tier = $offset >= 2 ? 'plenty' : 'limited';
+                break;
+            }
+        }
+
+        return [
+            'activityId' => (string) $activityId,
+            'date' => $isoDate,
+            'tier' => $tier,
+            'seats' => $confirmedSeats,
+        ];
+    }
+
+    private function normalizeBooleanResponse(mixed $response): ?bool
+    {
+        if (is_bool($response)) {
+            return $response;
+        }
+
+        if ($response instanceof stdClass && property_exists($response, 'return')) {
+            return $this->normalizeBooleanResponse($response->return);
+        }
+
+        if (is_array($response) && array_key_exists('return', $response)) {
+            return $this->normalizeBooleanResponse($response['return']);
+        }
+
+        if (is_string($response)) {
+            $normalized = strtolower(trim($response));
+            if ($normalized === '') {
+                return null;
+            }
+
+            if (in_array($normalized, ['1', 'true', 't', 'y', 'yes', 'available'], true)) {
+                return true;
+            }
+
+            if (in_array($normalized, ['0', 'false', 'f', 'n', 'no', 'unavailable'], true)) {
+                return false;
+            }
+        }
+
+        if (is_numeric($response)) {
+            return (float) $response > 0.0;
+        }
+
+        return null;
+    }
+
+    private function formatSoapDate(string $isoDate): string
+    {
+        try {
+            return (new DateTimeImmutable($isoDate))->format('m/d/Y');
+        } catch (\Exception) {
+            return $isoDate;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $activityConfig
+     * @return array<int, int>
+     */
+    private function extractActivityIds(array $activityConfig): array
+    {
+        $ids = [];
+
+        if (isset($activityConfig['activityId'])) {
+            $ids[] = $activityConfig['activityId'];
+        }
+
+        if (isset($activityConfig['activityIds']) && is_array($activityConfig['activityIds'])) {
+            foreach ($activityConfig['activityIds'] as $id) {
+                $ids[] = $id;
+            }
+        }
+
+        $normalized = [];
+        foreach ($ids as $id) {
+            if (is_numeric($id)) {
+                $normalized[] = (int) $id;
+            }
+        }
+
+        $normalized = array_values(array_unique($normalized));
+        sort($normalized);
+
+        return $normalized;
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -234,6 +234,11 @@ $apiEndpoints = [
         rawurlencode($supplierSlug),
         rawurlencode($activitySlug)
     ),
+    'availabilityMessages' => sprintf(
+        '/api/get-availability-messages.php?supplier=%s&activity=%s',
+        rawurlencode($supplierSlug),
+        rawurlencode($activitySlug)
+    ),
     'transportation' => sprintf(
         '/api/get-transportation.php?supplier=%s&activity=%s',
         rawurlencode($supplierSlug),

--- a/tests/phpunit/Services/AvailabilityMessagingServiceTest.php
+++ b/tests/phpunit/Services/AvailabilityMessagingServiceTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PonoRez\SGCForms\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use PonoRez\SGCForms\Services\AvailabilityMessagingService;
+use PonoRez\SGCForms\Services\SoapClientFactory;
+use RuntimeException;
+use SoapClient;
+
+final class AvailabilityMessagingServiceTest extends TestCase
+{
+    private const SUPPLIER_SLUG = 'supplier-slug';
+    private const ACTIVITY_SLUG = 'activity-slug';
+
+    public function testProbeMarksUnavailableWhenBaselineFails(): void
+    {
+        $responses = [
+            369 => [
+                '2024-08-01' => [
+                    2 => false,
+                ],
+            ],
+        ];
+
+        $client = new AvailabilityProbeSoapClient($responses);
+        $factory = new AvailabilityProbeSoapClientFactory($client);
+
+        $service = new AvailabilityMessagingService($factory);
+        $result = $service->probeTimeslots(
+            self::SUPPLIER_SLUG,
+            self::ACTIVITY_SLUG,
+            [
+                ['activityId' => 369, 'date' => '2024-08-01'],
+            ],
+            ['345' => 2]
+        );
+
+        self::assertSame(2, $result['requestedSeats']);
+        self::assertCount(1, $client->calls);
+        self::assertCount(1, $result['messages']);
+
+        $message = $result['messages'][0];
+        self::assertSame('369', $message['activityId']);
+        self::assertSame('2024-08-01', $message['date']);
+        self::assertSame('unavailable', $message['tier']);
+        self::assertSame(0, $message['seats']);
+    }
+
+    public function testProbeMarksPlentyWhenHigherTierSucceeds(): void
+    {
+        $responses = [
+            369 => [
+                '2024-08-02' => [
+                    2 => true,
+                    5 => true,
+                ],
+            ],
+        ];
+
+        $client = new AvailabilityProbeSoapClient($responses);
+        $factory = new AvailabilityProbeSoapClientFactory($client);
+
+        $service = new AvailabilityMessagingService($factory);
+        $result = $service->probeTimeslots(
+            self::SUPPLIER_SLUG,
+            self::ACTIVITY_SLUG,
+            [
+                ['activityId' => 369, 'date' => '2024-08-02'],
+            ],
+            ['345' => 2]
+        );
+
+        self::assertSame(2, $result['requestedSeats']);
+        self::assertCount(2, $client->calls);
+
+        $message = $result['messages'][0];
+        self::assertSame('plenty', $message['tier']);
+        self::assertSame(5, $message['seats']);
+    }
+
+    public function testProbeFallsBackToLimitedWhenOnlyOneExtraSeat(): void
+    {
+        $responses = [
+            369 => [
+                '2024-08-03' => [
+                    2 => true,
+                    5 => false,
+                    4 => false,
+                    3 => true,
+                ],
+            ],
+        ];
+
+        $client = new AvailabilityProbeSoapClient($responses);
+        $factory = new AvailabilityProbeSoapClientFactory($client);
+
+        $service = new AvailabilityMessagingService($factory);
+        $result = $service->probeTimeslots(
+            self::SUPPLIER_SLUG,
+            self::ACTIVITY_SLUG,
+            [
+                ['activityId' => 369, 'date' => '2024-08-03'],
+            ],
+            ['345' => 2]
+        );
+
+        self::assertSame(2, $result['requestedSeats']);
+        self::assertCount(4, $client->calls);
+
+        $message = $result['messages'][0];
+        self::assertSame('limited', $message['tier']);
+        self::assertSame(3, $message['seats']);
+    }
+
+    public function testProbeKeepsBaselineSeatsWhenNoAdditionalCapacity(): void
+    {
+        $responses = [
+            369 => [
+                '2024-08-04' => [
+                    2 => true,
+                    5 => false,
+                    4 => false,
+                    3 => false,
+                ],
+            ],
+        ];
+
+        $client = new AvailabilityProbeSoapClient($responses);
+        $factory = new AvailabilityProbeSoapClientFactory($client);
+
+        $service = new AvailabilityMessagingService($factory);
+        $result = $service->probeTimeslots(
+            self::SUPPLIER_SLUG,
+            self::ACTIVITY_SLUG,
+            [
+                ['activityId' => 369, 'date' => '2024-08-04'],
+            ],
+            ['345' => 2]
+        );
+
+        self::assertSame(2, $result['requestedSeats']);
+        self::assertCount(4, $client->calls);
+
+        $message = $result['messages'][0];
+        self::assertSame('limited', $message['tier']);
+        self::assertSame(2, $message['seats']);
+    }
+
+    public function testDuplicateTimeslotsAreProbedOnce(): void
+    {
+        $responses = [
+            369 => [
+                '2024-08-05' => [
+                    2 => true,
+                    5 => false,
+                    4 => false,
+                    3 => true,
+                ],
+            ],
+        ];
+
+        $client = new AvailabilityProbeSoapClient($responses);
+        $factory = new AvailabilityProbeSoapClientFactory($client);
+
+        $service = new AvailabilityMessagingService($factory);
+        $result = $service->probeTimeslots(
+            self::SUPPLIER_SLUG,
+            self::ACTIVITY_SLUG,
+            [
+                ['activityId' => 369, 'date' => '2024-08-05'],
+                ['activityId' => '369', 'date' => '2024-08-05'],
+                ['activityId' => 999, 'date' => '2024-08-05'],
+            ],
+            ['345' => 2]
+        );
+
+        // Baseline + three probes should be executed once.
+        self::assertCount(4, $client->calls);
+        self::assertCount(1, $result['messages']);
+
+        $message = $result['messages'][0];
+        self::assertSame('369', $message['activityId']);
+        self::assertSame('limited', $message['tier']);
+        self::assertSame(3, $message['seats']);
+    }
+}
+
+final class AvailabilityProbeSoapClientFactory implements SoapClientFactory
+{
+    public function __construct(private SoapClient $client)
+    {
+    }
+
+    public function build(): SoapClient
+    {
+        return $this->client;
+    }
+}
+
+final class AvailabilityProbeSoapClient extends SoapClient
+{
+    /** @var array<int, array<string, array<int, bool>>> */
+    private array $responses;
+
+    /** @var list<array{0:string,1:array}> */
+    public array $calls = [];
+
+    /**
+     * @param array<int, array<string, array<int, bool>>> $responses
+     */
+    public function __construct(array $responses)
+    {
+        $this->responses = $responses;
+        // Skip parent constructor; the stub does not need WSDL handling.
+    }
+
+    public function __soapCall(string $name, array $arguments, ?array $options = null, mixed $inputHeaders = null, mixed &$outputHeaders = null): mixed
+    {
+        $this->calls[] = [$name, $arguments];
+
+        if ($name !== 'checkActivityAvailability') {
+            throw new RuntimeException(sprintf('Unexpected SOAP call to "%s".', $name));
+        }
+
+        $payload = $arguments[0] ?? [];
+        $activityId = isset($payload['activityId']) ? (int) $payload['activityId'] : 0;
+        $dateKey = $this->normaliseDateKey((string) ($payload['date'] ?? ''));
+        $requested = isset($payload['requestedAvailability']) ? (int) $payload['requestedAvailability'] : 0;
+
+        return $this->responses[$activityId][$dateKey][$requested] ?? false;
+    }
+
+    private function normaliseDateKey(string $date): string
+    {
+        if ($date === '') {
+            return $date;
+        }
+
+        try {
+            return (new \DateTimeImmutable($date))->format('Y-m-d');
+        } catch (\Exception) {
+            return $date;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an AvailabilityMessagingService that batches baseline and incremental `checkActivityAvailability` probes and normalises the responses
- expose `/api/get-availability-messages.php` and extend the front end to fetch and cache seat messaging per timeslot
- track timeslot messaging state in the store and add PHPUnit coverage for the probing ladder

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dee9099ff88329886c336df7cd5b03