### PR TITLE
Cache availability months for faster calendar browsing

### DIFF
--- a/api/get-availability.php
+++ b/api/get-availability.php
@@ -49,7 +49,12 @@ try {
         }
     }
 
-    $service = new AvailabilityService(new SoapClientBuilder());
+    $availabilityCacheDirectory = UtilityService::projectRoot() . '/cache/availability';
+    $availabilityCache = is_writable(dirname($availabilityCacheDirectory))
+        ? new FileCache($availabilityCacheDirectory)
+        : new NullCache();
+
+    $service = new AvailabilityService(new SoapClientBuilder(), null, $availabilityCache);
     $result = $service->fetchCalendar(
         $params['supplier'],
         $params['activity'],

--- a/tests/phpunit/Services/AvailabilityTest.php
+++ b/tests/phpunit/Services/AvailabilityTest.php
@@ -45,9 +45,9 @@ final class AvailabilityTest extends TestCase
             'yearmonth_2024_3_ex' => $extended,
         ], JSON_THROW_ON_ERROR);
 
-        $capturedParams = null;
-        $httpFetcher = function (string $url, array $params) use (&$capturedParams, $httpResponse): string {
-            $capturedParams = $params;
+        $capturedRequests = [];
+        $httpFetcher = function (string $url, array $params) use (&$capturedRequests, $httpResponse): string {
+            $capturedRequests[] = $params;
             return $httpResponse;
         };
 
@@ -73,10 +73,12 @@ final class AvailabilityTest extends TestCase
             '2024-03'
         );
 
-        self::assertSame('COMMON_AVAILABILITYCHECKJSON', $capturedParams['action']);
-        self::assertSame('369', $capturedParams['activityid']);
-        self::assertSame('2024_3', $capturedParams['year_months']);
-        self::assertNotEmpty($capturedParams['minavailability']);
+        self::assertNotEmpty($capturedRequests);
+        $firstRequest = $capturedRequests[0];
+        self::assertSame('COMMON_AVAILABILITYCHECKJSON', $firstRequest['action']);
+        self::assertSame('369', $firstRequest['activityid']);
+        self::assertSame('2024_3', $firstRequest['year_months']);
+        self::assertNotEmpty($firstRequest['minavailability']);
 
         $calendar = $result['calendar'];
         self::assertSame(31, $calendar->count());


### PR DESCRIPTION
## Summary
- add a six-month availability month cache with a three-minute TTL inside `AvailabilityService`
- wire the availability API endpoint to provide a FileCache-backed store for the new cache
- adjust the availability service test harness to account for multiple month fetches

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e153cf43888329bebb450aae464c41