### PR TITLE
Remove transportation row from guest breakdown

### DIFF
--- a/assets/js/modules/availability.js
+++ b/assets/js/modules/availability.js
@@ -1095,24 +1095,6 @@ function renderTimeslots(state) {
                     list.appendChild(listItem);
                 });
 
-                if (pricingTotals.transportation > 0) {
-                    const transportationItem = createElement('li', {
-                        className: 'flex items-baseline justify-between gap-2 text-xs text-body/70',
-                    });
-
-                    transportationItem.appendChild(createElement('span', {
-                        className: 'font-medium text-body',
-                        text: 'Transportation',
-                    }));
-
-                    transportationItem.appendChild(createElement('span', {
-                        className: 'font-semibold text-body',
-                        text: formatCurrencyForState(state, pricingTotals.transportation),
-                    }));
-
-                    list.appendChild(transportationItem);
-                }
-
                 if (pricingTotals.upgrades > 0) {
                     const upgradesItem = createElement('li', {
                         className: 'flex items-baseline justify-between gap-2 text-xs text-body/70',


### PR DESCRIPTION
## Summary
- update availability timeslot rendering to drop the hard-coded Transportation row so only guest types appear

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39dd8cd388329b1a1e43ca2449d82