### PR TITLE
Adjust timeslot card styling

### DIFF
--- a/assets/js/modules/availability.js
+++ b/assets/js/modules/availability.js
@@ -998,7 +998,7 @@ function renderTimeslots(state) {
             const item = createElement('li', { className: 'w-full' });
 
             const label = createElement('label', {
-                className: 'group flex w-full cursor-pointer flex-col gap-2 rounded-2xl bg-[color:var(--brand-color)] p-1.5 sm:p-2',
+                className: 'group block w-full cursor-pointer',
                 attributes: { 'data-timeslot-id': timeslot.id },
             });
 
@@ -1021,7 +1021,7 @@ function renderTimeslots(state) {
             }
 
             const card = createElement('div', {
-                className: 'flex flex-col overflow-hidden rounded-xl bg-white outline outline-1 outline-offset-[-1px] outline-black/10 shadow-sm transition focus-within:ring-2 focus-within:ring-[color:var(--brand-color)] focus-within:ring-offset-2 focus-within:ring-offset-white',
+                className: 'flex flex-col overflow-hidden rounded-xl border border-slate-200 bg-white transition focus-within:border-[color:var(--brand-color)]',
             });
 
             const headerRow = createElement('div', {
@@ -1169,7 +1169,8 @@ function renderTimeslots(state) {
             }
 
             if (radio.checked) {
-                card.classList.add('ring-2', 'ring-[color:var(--brand-color)]', 'ring-offset-2', 'ring-offset-white');
+                card.classList.remove('border-slate-200');
+                card.classList.add('border-2', 'border-[color:var(--brand-color)]');
                 radioVisual.classList.add('border-transparent', 'bg-[color:var(--brand-color)]');
                 radioDot.classList.add('bg-white');
             }


### PR DESCRIPTION
## Summary
- remove the brand-colored wrapper around timeslot cards so the card controls spacing
- switch the timeslot card to a flat bordered style and keep the selected state as a border highlight

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b8c8c58883299ea0e7dfc5e9e26f